### PR TITLE
Support cerebral 0.34

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-node_modules
+.kotatsu
 dist
+node_modules

--- a/app/main.js
+++ b/app/main.js
@@ -11,9 +11,6 @@ import ColorChanger from './components/ColorChanger';
 
 const controller = Controller(Model({}));
 
-import ModulesProvider from 'cerebral-provider-modules';
-controller.addContextProvider(ModulesProvider);
-
 controller.addModules({
   example: Example(),
 

--- a/app/main.js
+++ b/app/main.js
@@ -11,10 +11,13 @@ import ColorChanger from './components/ColorChanger';
 
 const controller = Controller(Model({}));
 
+import ModulesProvider from 'cerebral-provider-modules';
+controller.addContextProvider(ModulesProvider);
+
 controller.addModules({
   example: Example(),
 
-  http: Http(),
+  'cerebral-module-http': Http(),
   devtools: Devtools(),
   router: Router({
     '/': 'example.redirectRoot',

--- a/package.json
+++ b/package.json
@@ -33,21 +33,20 @@
     "cerebral-addons": "^0.5.4",
     "cerebral-model-baobab": "^0.4.8",
     "cerebral-module-devtools": "^0.6.4",
-    "cerebral-module-http": "^0.1.1",
+    "cerebral-module-http": "^0.2.0",
     "cerebral-module-router": "^0.14.4",
     "cerebral-view-react": "^0.11.17",
     "express": "^4.13.4",
-    "react": "^15.0.2",
-    "react-dom": "^15.0.2"
+    "react": "^15.1.0",
+    "react-dom": "^15.1.0"
   },
   "devDependencies": {
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-preset-react": "^6.5.0",
     "babel-preset-react-hmre": "^1.1.1",
     "babel-preset-stage-0": "^6.5.0",
-    "cerebral-provider-modules": "^0.1.1",
     "concurrently": "^2.1.0",
-    "cross-env": "^1.0.7",
+    "cross-env": "^1.0.8",
     "css-loader": "^0.23.1",
     "kotatsu": "^0.13.0",
     "style-loader": "^0.13.1"

--- a/package.json
+++ b/package.json
@@ -29,26 +29,26 @@
   },
   "dependencies": {
     "baobab": "^2.3.3",
-    "cerebral": "^0.33.24",
-    "cerebral-addons": "^0.4.10",
-    "cerebral-model-baobab": "^0.4.7",
-    "cerebral-module-devtools": "^0.5.3",
+    "cerebral": "^0.34.0",
+    "cerebral-addons": "^0.5.4",
+    "cerebral-model-baobab": "^0.4.8",
+    "cerebral-module-devtools": "^0.6.4",
     "cerebral-module-http": "^0.1.1",
-    "cerebral-module-router": "^0.12.5",
-    "cerebral-view-react": "^0.11.6",
+    "cerebral-module-router": "^0.14.4",
+    "cerebral-view-react": "^0.11.17",
     "express": "^4.13.4",
-    "react": "^0.14.7",
-    "react-dom": "^0.14.7"
+    "react": "^15.0.2",
+    "react-dom": "^15.0.2"
   },
   "devDependencies": {
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-preset-react": "^6.5.0",
-    "babel-preset-react-hmre": "^1.1.0",
+    "babel-preset-react-hmre": "^1.1.1",
     "babel-preset-stage-0": "^6.5.0",
-    "concurrently": "^2.0.0",
+    "concurrently": "^2.1.0",
     "cross-env": "^1.0.7",
     "css-loader": "^0.23.1",
-    "kotatsu": "^0.10.0",
-    "style-loader": "^0.13.0"
+    "kotatsu": "^0.13.0",
+    "style-loader": "^0.13.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "babel-preset-react": "^6.5.0",
     "babel-preset-react-hmre": "^1.1.1",
     "babel-preset-stage-0": "^6.5.0",
+    "cerebral-provider-modules": "^0.1.1",
     "concurrently": "^2.1.0",
     "cross-env": "^1.0.7",
     "css-loader": "^0.23.1",


### PR DESCRIPTION
~~As well as updating the dependencies, this adds the following to main.js~~

``` js
import ModulesProvider from 'cerebral-provider-modules';
controller.addContextProvider(ModulesProvider);
```

~~This can be removed later when cerebral-module-http is updated to support cerebral 0.34~~

Final commit updates to `cerebral-module-http@0.2.0` which now supports cerebral 0.34. 
